### PR TITLE
Fix unpickling

### DIFF
--- a/examples/ImageNet Pretrained Network (VGG_S).ipynb
+++ b/examples/ImageNet Pretrained Network (VGG_S).ipynb
@@ -127,7 +127,7 @@
    "source": [
     "import pickle\n",
     "\n",
-    "model = pickle.load(open('vgg_cnn_s.pkl'))\n",
+    "model = pickle.load(open('vgg_cnn_s.pkl','rb'),encoding='latin-1')\n",
     "CLASSES = model['synset words']\n",
     "MEAN_IMAGE = model['mean image']\n",
     "\n",


### PR DESCRIPTION
UnicodeDecodeError would be thrown if the file is open()ed without byte mode or if no coding is passed to pickle.load.