### PR TITLE
adding missing dropout layers to VGG16 and VG19

### DIFF
--- a/modelzoo/vgg16.py
+++ b/modelzoo/vgg16.py
@@ -33,11 +33,11 @@ def build_model():
     net['conv5_2'] = ConvLayer(net['conv5_1'], 512, 3, pad=1)
     net['conv5_3'] = ConvLayer(net['conv5_2'], 512, 3, pad=1)
     net['pool5'] = PoolLayer(net['conv5_3'], 2)
-    net['fc6_dropout'] = DropoutLayer(net['pool5'], p=0.5)
-    net['fc6'] = DenseLayer(net['fc6_dropout'], num_units=4096)
+    net['fc6'] = DenseLayer(net['pool5'], num_units=4096)
+    net['fc6_dropout'] = DropoutLayer(net['fc6'], p=0.5)
+    net['fc7'] = DenseLayer(net['fc6_dropout'], num_units=4096)
     net['fc7_dropout'] = DropoutLayer(net['fc7'], p=0.5)
-    net['fc7'] = DenseLayer(net['fc7_dropout'], num_units=4096)
-    net['fc8'] = DenseLayer(net['fc7'], num_units=1000, nonlinearity=None)
+    net['fc8'] = DenseLayer(net['fc7_dropout'], num_units=1000, nonlinearity=None)
     net['prob'] = NonlinearityLayer(net['fc8'], softmax)
 
     return net

--- a/modelzoo/vgg16.py
+++ b/modelzoo/vgg16.py
@@ -33,11 +33,11 @@ def build_model():
     net['conv5_2'] = ConvLayer(net['conv5_1'], 512, 3, pad=1)
     net['conv5_3'] = ConvLayer(net['conv5_2'], 512, 3, pad=1)
     net['pool5'] = PoolLayer(net['conv5_3'], 2)
-    net['dropout6'] = DropoutLayer(net['pool5'], p=0.5)
-    net['fc7'] = DenseLayer(net['dropout6'], num_units=4096)
-    net['dropout8'] = DropoutLayer(net['fc7'], p=0.5)
-    net['fc9'] = DenseLayer(net['dropout8'], num_units=4096)
-    net['fc10'] = DenseLayer(net['fc9'], num_units=1000, nonlinearity=None)
-    net['prob'] = NonlinearityLayer(net['fc10'], softmax)
+    net['fc6_dropout'] = DropoutLayer(net['pool5'], p=0.5)
+    net['fc6'] = DenseLayer(net['fc6_dropout'], num_units=4096)
+    net['fc7_dropout'] = DropoutLayer(net['fc7'], p=0.5)
+    net['fc7'] = DenseLayer(net['fc7_dropout'], num_units=4096)
+    net['fc8'] = DenseLayer(net['fc7'], num_units=1000, nonlinearity=None)
+    net['prob'] = NonlinearityLayer(net['fc8'], softmax)
 
     return net

--- a/modelzoo/vgg16.py
+++ b/modelzoo/vgg16.py
@@ -6,7 +6,7 @@
 # Download pretrained weights from:
 # https://s3.amazonaws.com/lasagne/recipes/pretrained/imagenet/vgg16.pkl
 
-from lasagne.layers import InputLayer, DenseLayer, NonlinearityLayer
+from lasagne.layers import InputLayer, DenseLayer, NonlinearityLayer, DropoutLayer
 from lasagne.layers.dnn import Conv2DDNNLayer as ConvLayer
 from lasagne.layers import Pool2DLayer as PoolLayer
 from lasagne.nonlinearities import softmax
@@ -33,9 +33,11 @@ def build_model():
     net['conv5_2'] = ConvLayer(net['conv5_1'], 512, 3, pad=1)
     net['conv5_3'] = ConvLayer(net['conv5_2'], 512, 3, pad=1)
     net['pool5'] = PoolLayer(net['conv5_3'], 2)
-    net['fc6'] = DenseLayer(net['pool5'], num_units=4096)
-    net['fc7'] = DenseLayer(net['fc6'], num_units=4096)
-    net['fc8'] = DenseLayer(net['fc7'], num_units=1000, nonlinearity=None)
-    net['prob'] = NonlinearityLayer(net['fc8'], softmax)
+    net['dropout6'] = DropoutLayer(net['pool5'], p=0.5)
+    net['fc7'] = DenseLayer(net['dropout6'], num_units=4096)
+    net['dropout8'] = DropoutLayer(net['fc7'], p=0.5)
+    net['fc9'] = DenseLayer(net['dropout8'], num_units=4096)
+    net['fc10'] = DenseLayer(net['fc9'], num_units=1000, nonlinearity=None)
+    net['prob'] = NonlinearityLayer(net['fc10'], softmax)
 
     return net

--- a/modelzoo/vgg19.py
+++ b/modelzoo/vgg19.py
@@ -36,11 +36,11 @@ def build_model():
     net['conv5_3'] = ConvLayer(net['conv5_2'], 512, 3, pad=1)
     net['conv5_4'] = ConvLayer(net['conv5_3'], 512, 3, pad=1)
     net['pool5'] = PoolLayer(net['conv5_4'], 2)
-    net['dropout6'] = DropoutLayer(net['pool5'], p=0.5)
-    net['fc7'] = DenseLayer(net['dropout6'], num_units=4096)
-    net['dropout8'] = DropoutLayer(net['fc7'], p=0.5)
-    net['fc9'] = DenseLayer(net['dropout8'], num_units=4096)
-    net['fc10'] = DenseLayer(net['fc9'], num_units=1000, nonlinearity=None)
-    net['prob'] = NonlinearityLayer(net['fc10'], softmax)
+    net['fc6_dropout'] = DropoutLayer(net['pool5'], p=0.5)
+    net['fc6'] = DenseLayer(net['fc6_dropout'], num_units=4096)
+    net['fc7_dropout'] = DropoutLayer(net['fc6'], p=0.5)
+    net['fc7'] = DenseLayer(net['fc7_dropout'], num_units=4096)
+    net['fc8'] = DenseLayer(net['fc7'], num_units=1000, nonlinearity=None)
+    net['prob'] = NonlinearityLayer(net['fc8'], softmax)
 
     return net

--- a/modelzoo/vgg19.py
+++ b/modelzoo/vgg19.py
@@ -36,11 +36,11 @@ def build_model():
     net['conv5_3'] = ConvLayer(net['conv5_2'], 512, 3, pad=1)
     net['conv5_4'] = ConvLayer(net['conv5_3'], 512, 3, pad=1)
     net['pool5'] = PoolLayer(net['conv5_4'], 2)
-    net['fc6_dropout'] = DropoutLayer(net['pool5'], p=0.5)
-    net['fc6'] = DenseLayer(net['fc6_dropout'], num_units=4096)
-    net['fc7_dropout'] = DropoutLayer(net['fc6'], p=0.5)
-    net['fc7'] = DenseLayer(net['fc7_dropout'], num_units=4096)
-    net['fc8'] = DenseLayer(net['fc7'], num_units=1000, nonlinearity=None)
+    net['fc6'] = DenseLayer(net['pool5'], num_units=4096)
+    net['fc6_dropout'] = DropoutLayer(net['fc6'], p=0.5)
+    net['fc7'] = DenseLayer(net['fc6_dropout'], num_units=4096)
+    net['fc7_dropout'] = DropoutLayer(net['fc7'], p=0.5)
+    net['fc8'] = DenseLayer(net['fc7_dropout'], num_units=1000, nonlinearity=None)
     net['prob'] = NonlinearityLayer(net['fc8'], softmax)
 
     return net

--- a/modelzoo/vgg19.py
+++ b/modelzoo/vgg19.py
@@ -36,9 +36,11 @@ def build_model():
     net['conv5_3'] = ConvLayer(net['conv5_2'], 512, 3, pad=1)
     net['conv5_4'] = ConvLayer(net['conv5_3'], 512, 3, pad=1)
     net['pool5'] = PoolLayer(net['conv5_4'], 2)
-    net['fc6'] = DenseLayer(net['pool5'], num_units=4096)
-    net['fc7'] = DenseLayer(net['fc6'], num_units=4096)
-    net['fc8'] = DenseLayer(net['fc7'], num_units=1000, nonlinearity=None)
-    net['prob'] = NonlinearityLayer(net['fc8'], softmax)
+    net['dropout6'] = DropoutLayer(net['pool5'], p=0.5)
+    net['fc7'] = DenseLayer(net['dropout6'], num_units=4096)
+    net['dropout8'] = DropoutLayer(net['fc7'], p=0.5)
+    net['fc9'] = DenseLayer(net['dropout8'], num_units=4096)
+    net['fc10'] = DenseLayer(net['fc9'], num_units=1000, nonlinearity=None)
+    net['prob'] = NonlinearityLayer(net['fc10'], softmax)
 
     return net


### PR DESCRIPTION
According to the paper ["Very Deep Convolutional Networks for Large-Scale Image Recognition"](http://arxiv.org/abs/1409.1556) there are two dropout layers (ratio 0.5) for the first two fully-connected layers in VGG16 and VGG19.

I added the two dropout layers and it drastically reduces overfitting.
