### PR TITLE
Added trainable=True. Otherwise hid_init is trained.

### DIFF
--- a/examples/lstm_text_generation.py
+++ b/examples/lstm_text_generation.py
@@ -148,7 +148,7 @@ def main(num_epochs=NUM_EPOCHS):
     cost = T.nnet.categorical_crossentropy(network_output,target_values).mean()
 
     # Retrieve all parameters from the network
-    all_params = lasagne.layers.get_all_params(l_out)
+    all_params = lasagne.layers.get_all_params(l_out,trainable=True)
 
     # Compute AdaGrad updates for training
     print("Computing updates ...")


### PR DESCRIPTION
I added the trainable=True tag to the get_all_params function.
Otherwise hid_init is trained anyway, even if learn_init (RNN/GRU/LSTM) is set to false, which is the default value.

Suffered from it for a week of 2 until I discovered it...
Should be added to the general recurrent layer documentation too?