### PR TITLE
Unify argument order of stride, pad in resnet50 model

### DIFF
--- a/examples/resnet50/ImageNet Pretrained Network (ResNet-50).ipynb
+++ b/examples/resnet50/ImageNet Pretrained Network (ResNet-50).ipynb
@@ -436,7 +436,7 @@
     "    net = []\n",
     "    net.append((\n",
     "            names[0], \n",
-    "            ConvLayer(incoming_layer, num_filters, filter_size, pad, stride, \n",
+    "            ConvLayer(incoming_layer, num_filters, filter_size, stride, pad, \n",
     "                      flip_filters=False, nonlinearity=None) if use_bias \n",
     "            else ConvLayer(incoming_layer, num_filters, filter_size, stride, pad, b=None, \n",
     "                           flip_filters=False, nonlinearity=None)\n",
@@ -622,7 +622,7 @@
     "net['input'] = InputLayer((None, 3, 224, 224))\n",
     "sub_net, parent_layer_name = build_simple_block(\n",
     "    net['input'], ['conv1', 'bn_conv1', 'conv1_relu'],\n",
-    "    64, 7, 3, 2, use_bias=True)\n",
+    "    64, 7, 2, 3, use_bias=True)\n",
     "net.update(sub_net)\n",
     "net['pool1'] = PoolLayer(net[parent_layer_name], pool_size=3, stride=2, pad=0, mode='max', ignore_border=False)"
    ]

--- a/modelzoo/resnet50.py
+++ b/modelzoo/resnet50.py
@@ -59,7 +59,7 @@ def build_simple_block(incoming_layer, names,
     net = []
     net.append((
             names[0],
-            ConvLayer(incoming_layer, num_filters, filter_size, pad, stride,
+            ConvLayer(incoming_layer, num_filters, filter_size, stride, pad,
                       flip_filters=False, nonlinearity=None) if use_bias
             else ConvLayer(incoming_layer, num_filters, filter_size, stride, pad, b=None,
                            flip_filters=False, nonlinearity=None)
@@ -154,7 +154,7 @@ def build_model():
     net['input'] = InputLayer((None, 3, 224, 224))
     sub_net, parent_layer_name = build_simple_block(
         net['input'], ['conv1', 'bn_conv1', 'conv1_relu'],
-        64, 7, 3, 2, use_bias=True)
+        64, 7, 2, 3, use_bias=True)
     net.update(sub_net)
     net['pool1'] = PoolLayer(net[parent_layer_name], pool_size=3, stride=2, pad=0, mode='max', ignore_border=False)
     block_size = list('abc')


### PR DESCRIPTION
Fixes #91 -- in one of the functions for building the resnet50 model, pad and stride was inadvertently swapped. It was also swapped when the function was called, so the model was correct, but it's nevertheless confusing.