### PR TITLE
densenet example: avoid a float64 cast

### DIFF
--- a/papers/densenet/train_test.py
+++ b/papers/densenet/train_test.py
@@ -142,7 +142,8 @@ def train_test(depth, growth_rate, dropout, augment, validate, epochs,
     test_loss = lasagne.objectives.categorical_crossentropy(test_prediction,
                                                             target_var).mean()
     test_err = 1 - lasagne.objectives.categorical_accuracy(test_prediction,
-                                                           target_var).mean()
+                                                           target_var).mean(
+                                                  dtype=theano.config.floatX)
     test_fn = theano.function([input_var, target_var], [test_loss, test_err])
 
     # Finally, launch the training loop.


### PR DESCRIPTION
It appears that this particular mean() operation causes a float64 cast unless you tell it not to. I have `warn_float64=raise` in my .theanorc and so it raises an exception about it. (I'm using recent master of lasagne+theano, on ubuntu.)

I have not tested whether this change affects convergence.